### PR TITLE
Map IMDB labels to 0/1 rather than (Unk)/1/2.

### DIFF
--- a/torchtext/datasets/imdb.py
+++ b/torchtext/datasets/imdb.py
@@ -69,7 +69,7 @@ class IMDB(data.Dataset):
             Remaining keyword arguments: Passed to the splits method.
         """
         TEXT = data.Field()
-        LABEL = data.Field(sequential=False)
+        LABEL = data.Field(sequential=False, unk_token=None)
 
         train, test = cls.splits(TEXT, LABEL, root=root, **kwargs)
 


### PR DESCRIPTION
When using the IMDB dataset's `iters` method, leaving `unk_token=<unk>` causes the numericalized labels to map to 1/2 rather than 0/1. Proposing a minor change where the labels are mapped to 0/1 instead.